### PR TITLE
Cancel Change Avatarボタンの誤字 (Cancel > Chancel) を修正

### DIFF
--- a/Editor/AvatarUploadSettingEditor.cs
+++ b/Editor/AvatarUploadSettingEditor.cs
@@ -91,7 +91,7 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
                 }
 
                 EditorGUI.BeginDisabledGroup(descriptor.IsNull());
-                if (GUILayout.Button("Chancel Change Avatar"))
+                if (GUILayout.Button("Cancel Change Avatar"))
                     _settingAvatar = false;
                 EditorGUI.EndDisabledGroup();
             }


### PR DESCRIPTION
たまたま見つけて、自分でも直せるレベルの改変だったので、修正の上プルリクを送りました