### PR TITLE
feat: add drag & drop avatar upload feature

### DIFF
--- a/Editor/ContinuousAvatarUploader.cs
+++ b/Editor/ContinuousAvatarUploader.cs
@@ -574,7 +574,19 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
                     continue;
                 }
                 EditorGUILayout.BeginHorizontal();
-                EditorGUILayout.ObjectField(tempSetting.avatarName, tempSetting.avatarDescriptor.TryResolve(), typeof(GameObject), true);
+                EditorGUI.BeginChangeCheck();
+                var newDescriptor = EditorGUILayout.ObjectField(tempSetting.avatarName, tempSetting.avatarDescriptor.TryResolve(), typeof(VRCAvatarDescriptor), true) as VRCAvatarDescriptor;
+                if (EditorGUI.EndChangeCheck() && newDescriptor != null)
+                {
+                    var newTempSetting = CreateTemporarySettingFromDescriptor(newDescriptor);
+                    if (newTempSetting != null)
+                    {
+                        // Replace the old setting with the new one
+                        _tempSettingsAsset.RemoveTemporarySetting(tempSetting);
+                        _tempSettingsAsset.AddTemporarySetting(newTempSetting);
+                        return;
+                    }
+                }
 
                 if (GUILayout.Button("Remove", GUILayout.Width(60)))
                 {

--- a/Editor/TemporarySettingsAsset.cs
+++ b/Editor/TemporarySettingsAsset.cs
@@ -1,0 +1,204 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace Anatawa12.ContinuousAvatarUploader.Editor
+{
+    internal class TemporarySettingsAsset : ScriptableObject
+    {
+        public const string AssetPath = "Assets/com.anatawa12.continuous-avatar-uploader.temporary-settings.asset";
+
+        /// <summary>
+        /// The list of temporary avatar upload settings created via drag & drop.
+        /// </summary>
+        public List<AvatarUploadSetting> temporarySettings = new List<AvatarUploadSetting>();
+
+        /// <summary>
+        /// Temporary platform settings for drag & drop avatars
+        /// </summary>
+        public bool tempWindowsEnabled = true;
+        public bool tempAndroidEnabled = true;
+        public bool tempIosEnabled = true;
+
+        private bool isDeleting = false;
+        private static bool isReloading = false;
+
+        static TemporarySettingsAsset()
+        {
+            AssemblyReloadEvents.beforeAssemblyReload += () => isReloading = true;
+        }
+
+        private void OnEnable()
+        {
+            hideFlags = HideFlags.DontUnloadUnusedAsset;
+        }
+
+        private void OnDisable()
+        {
+            if (!isDeleting && !isReloading)
+                Debug.LogError("TemporarySettingsAsset is unloaded unexpectedly. You should not unload this asset manually, it should use 'Delete' method instead.", this);
+        }
+
+        private void OnDestroy()
+        {
+            if (!isDeleting)
+                Debug.Log("TemporarySettingsAsset is destroyed unexpectedly. You should not destroy this asset manually, it should use 'Delete' method instead.", this);
+        }
+
+        public static TemporarySettingsAsset? Load()
+        {
+            var loaded = AssetDatabase.LoadAssetAtPath<TemporarySettingsAsset>(AssetPath);
+            return loaded ? loaded : null;
+        }
+
+        public static TemporarySettingsAsset LoadOrCreateInMemory()
+        {
+            var loaded = Load();
+            if (loaded == null)
+            {
+                // Create instance in memory only, don't create asset file yet
+                loaded = CreateInstance<TemporarySettingsAsset>();
+                loaded.InitializePlatformSettings();
+            }
+            return loaded;
+        }
+
+        public void InitializePlatformSettings()
+        {
+            tempWindowsEnabled = Preferences.UploadFor(TargetPlatform.Windows);
+            tempAndroidEnabled = Preferences.UploadFor(TargetPlatform.Android);
+            tempIosEnabled = Preferences.UploadFor(TargetPlatform.iOS);
+        }
+
+        public void Save()
+        {
+            if (this == null)
+            {
+                throw new NullReferenceException("this TemporarySettingsAsset is destroyed. You cannot save it.");
+            }
+
+            // Only save if this is already an asset in the AssetDatabase
+            if (AssetDatabase.Contains(this))
+            {
+                EditorUtility.SetDirty(this);
+                AssetDatabase.SaveAssetIfDirty(this);
+            }
+        }
+
+        public void AddTemporarySetting(AvatarUploadSetting setting)
+        {
+            if (setting == null) return;
+
+            if (AssetDatabase.Contains(this))
+            {
+                var settingPath = AssetDatabase.GetAssetPath(setting);
+                if (string.IsNullOrEmpty(settingPath))
+                {
+                    AssetDatabase.AddObjectToAsset(setting, this);
+                }
+            }
+
+            if (!temporarySettings.Contains(setting))
+            {
+                temporarySettings.Add(setting);
+            }
+
+            if (AssetDatabase.Contains(this))
+            {
+                Save();
+            }
+        }
+
+        public void RemoveTemporarySetting(AvatarUploadSetting setting)
+        {
+            if (setting == null) return;
+
+            temporarySettings.Remove(setting);
+
+            if (AssetDatabase.Contains(this) && AssetDatabase.Contains(setting))
+            {
+                var assetPath = AssetDatabase.GetAssetPath(setting);
+                if (!string.IsNullOrEmpty(assetPath) && assetPath == AssetDatabase.GetAssetPath(this))
+                {
+                    DestroyImmediate(setting, true);
+                }
+            }
+            else if (!AssetDatabase.Contains(this) && !AssetDatabase.Contains(setting))
+            {
+                DestroyImmediate(setting);
+            }
+
+            if (AssetDatabase.Contains(this))
+            {
+                Save();
+            }
+        }
+
+        public void SaveAsAsset()
+        {
+            if (this == null)
+            {
+                throw new NullReferenceException("this TemporarySettingsAsset is destroyed. You cannot save it.");
+            }
+
+            if (!AssetDatabase.Contains(this))
+            {
+                AssetDatabase.CreateAsset(this, AssetPath);
+
+                foreach (var setting in temporarySettings)
+                {
+                    if (setting != null && !AssetDatabase.Contains(setting))
+                    {
+                        AssetDatabase.AddObjectToAsset(setting, this);
+                    }
+                }
+
+                EditorUtility.SetDirty(this);
+                AssetDatabase.SaveAssetIfDirty(this);
+            }
+            else
+            {
+                Save();
+            }
+        }
+
+        public void ClearAllTemporarySettings()
+        {
+            // Remove all sub-assets
+            foreach (var setting in temporarySettings)
+            {
+                if (setting != null)
+                {
+                    var assetPath = AssetDatabase.GetAssetPath(setting);
+                    if (!string.IsNullOrEmpty(assetPath) && assetPath == AssetDatabase.GetAssetPath(this))
+                    {
+                        DestroyImmediate(setting, true);
+                    }
+                }
+            }
+
+            temporarySettings.Clear();
+            Save();
+        }
+
+        public void Delete()
+        {
+            if (AssetDatabase.LoadAssetAtPath<TemporarySettingsAsset>(AssetPath) == this)
+            {
+                isDeleting = true;
+                // Clear all sub-assets first
+                ClearAllTemporarySettings();
+                AssetDatabase.DeleteAsset(AssetPath);
+            }
+            else
+            {
+                Debug.Log("Deleting TemporarySettingsAsset not at desired location. Can be a bug.", this);
+                isDeleting = true;
+                DestroyImmediate(this);
+            }
+        }
+    }
+}

--- a/Editor/TemporarySettingsAsset.cs.meta
+++ b/Editor/TemporarySettingsAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d23a3e2d11ce9ba42a00efd828028491
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/UploadOrchestrator.cs
+++ b/Editor/UploadOrchestrator.cs
@@ -10,6 +10,7 @@ using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using VRC.SDK3A.Editor;
+using VRC.SDK3.Avatars.Components;
 using VRC.SDKBase.Editor;
 
 namespace Anatawa12.ContinuousAvatarUploader.Editor
@@ -247,6 +248,7 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
                             asset.uploadErrors.Add(new UploadErrorInfo
                             {
                                 uploadingAvatar = avatarToUpload,
+                                avatarName = avatarToUpload.name,
                                 targetPlatform = asset.uploadingTargetPlatform,
                                 message = exception1.ToString()
                             });
@@ -269,6 +271,7 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
                                 asset.uploadErrors.Add(new UploadErrorInfo
                                 {
                                     uploadingAvatar = avatarToUpload,
+                                    avatarName = avatarToUpload.name,
                                     targetPlatform = asset.uploadingTargetPlatform,
                                     message = exception1.ToString()
                                 });

--- a/Editor/UploaderProgressAsset.cs
+++ b/Editor/UploaderProgressAsset.cs
@@ -148,6 +148,7 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
     {
         public TargetPlatform targetPlatform;
         public AvatarUploadSetting uploadingAvatar;
+        public string avatarName; // Name of the avatar being uploaded for fallback
         public string message;
     }
 


### PR DESCRIPTION
以前 #81 で書いた内容ですが、設定ファイルを作成することなく、Hierarchy上にあるアバターやPrefabをD&Dしてアップロードできる機能を追加してみました。
Editor画面に直接ドラッグして、簡単にアップロード対象として追加できるようになります。

### 新しく「Drag & Drop Upload」セクションを追加
「Drag & Drop Upload」セクションを追加し、D&Dするとアバター一覧が表示されます。
簡易用なので細かな設定は省いていますが必要そうであれば追加します。
TemporarySettingsAssetで引き回す都合上D&D用の場所をつくってます。
<img width="300" alt="image" src="https://github.com/user-attachments/assets/597b8746-b7b5-4585-8420-5c139fb3d5ba" />

### 設定管理
エラー発生時などで引き回すために、アップロード実行時にTemporarySettingsAssetを作成し、それをアップロード対象に含める形で既存機能に統合しています。
ウィンドウを閉じたときなど終了時にTemporarySettingsAssetは削除します。

既存機能には影響がないようにしたつもりですが、なにか問題があればマージせずに閉じてもらっても大丈夫です。
よろしくお願いします。