### PR TITLE
feat: auto restart editor during upload or before first upload

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog].
 ## [Unreleased]
 ### Added
 
+- Allow user automatically restart editor during uploading. [`#144`](https://github.com/anatawa12/ContinuousAvatarUploader/pull/144)
+  - Restart editor before first upload.
+  - Restart editor after configured numbers of avatars was upload.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog].
 ## [Unreleased]
 ### Added
 
+- Allow user automatically restart editor during uploading. [`#144`](https://github.com/anatawa12/ContinuousAvatarUploader/pull/144)
+  - Restart editor before first upload.
+  - Restart editor after configured numbers of avatars was upload.
+
 ### Changed
 
 ### Deprecated

--- a/Editor/ContinuousAvatarUploader.cs
+++ b/Editor/ContinuousAvatarUploader.cs
@@ -35,6 +35,7 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
         [SerializeField] private Vector2 temporaryAvatarsScroll;
         [SerializeField] private List<UploadErrorInfo> uploadErrors = new List<UploadErrorInfo>();
         [SerializeField] private bool dragDropFoldout = false;
+        [SerializeField] private bool restartOptionsFoldout = false;
 
         private UploaderProgressAsset progressAsset;
 
@@ -175,6 +176,38 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
             Preferences.RetryCount = EditorGUILayout.IntField(
                 new GUIContent("Retry Count", "The number of retries to attempt for each upload. Zero means no retries, so only one attempt will be made."),
                 Preferences.RetryCount);
+
+            restartOptionsFoldout = EditorGUILayout.Foldout(restartOptionsFoldout, "Restart Options", true, EditorStyles.foldoutHeader);
+            if (restartOptionsFoldout)
+            {
+                EditorGUI.indentLevel++;
+                var initialLabelWidth = EditorGUIUtility.labelWidth;
+                EditorGUIUtility.labelWidth = 200;
+
+                EditorGUILayout.HelpBox(
+                    "Auto restart feature only tested on Windows and may not work correctly on other platforms.",
+                    MessageType.Warning);
+
+                Preferences.RestartBeforeFirstUpload = EditorGUILayout.ToggleLeft(
+                    new GUIContent("Restart Editor before first upload",
+                        "If this is enabled, CAU will restart the editor before first upload to reduce memory usage."),
+                    Preferences.RestartBeforeFirstUpload);
+                Preferences.IsRestartEditorAfterUploadsEnabled = EditorGUILayout.ToggleLeft(
+                    new GUIContent("Restart Editor during upload",
+                        "If this is enabled, CAU will restart the editor during upload to reduce memory usage."),
+                    Preferences.IsRestartEditorAfterUploadsEnabled);
+                if (Preferences.IsRestartEditorAfterUploadsEnabled)
+                {
+                    var restartEditorAfterUploads = EditorGUILayout.IntField(
+                        new GUIContent("Restart Editor After Uploads", "The number of uploads after which the editor will be restarted."),
+                        Preferences.RestartEditorAfterUploads);
+                    if (restartEditorAfterUploads > 0)
+                        Preferences.RestartEditorAfterUploads = restartEditorAfterUploads;
+                }
+
+                EditorGUIUtility.labelWidth = initialLabelWidth;
+                EditorGUI.indentLevel--;
+            }
 
             EditorGUILayout.Space();
             dragDropFoldout = EditorGUILayout.Foldout(dragDropFoldout, new GUIContent("Drag & Drop Upload"), true, EditorStyles.foldoutHeader);
@@ -412,6 +445,9 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
             progress.rollbackPlatform = Preferences.RollbackBuildPlatform;
             progress.retryCount = Preferences.RetryCount;
             progress.continueUploadOnError = Preferences.ContinueUploadOnError;
+            progress.restartBeforeFirstUpload = Preferences.RestartBeforeFirstUpload;
+            progress.restartDuringUpload = Preferences.IsRestartEditorAfterUploadsEnabled;
+            progress.restartAfterUploads = Preferences.RestartEditorAfterUploads;
             UploadOrchestrator.StartUpload(progress);
         }
 

--- a/Editor/ContinuousAvatarUploader.cs
+++ b/Editor/ContinuousAvatarUploader.cs
@@ -187,6 +187,9 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
                 EditorGUILayout.HelpBox(
                     "Auto restart feature only tested on Windows and may not work correctly on other platforms.",
                     MessageType.Warning);
+                EditorGUILayout.HelpBox(
+                    "You need to ensure that your editor window is foreground and focus at least once after the editor restart.",
+                    MessageType.Warning);
 
                 Preferences.RestartBeforeFirstUpload = EditorGUILayout.ToggleLeft(
                     new GUIContent("Restart Editor before first upload",

--- a/Editor/Preferences.cs
+++ b/Editor/Preferences.cs
@@ -58,7 +58,7 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
 
         public static int RestartEditorAfterUploads
         {
-            get => EditorPrefs.GetInt(EditorPrefsPrefix + "restart-editor-after-uploads", 0);
+            get => EditorPrefs.GetInt(EditorPrefsPrefix + "restart-editor-after-uploads", 1);
             set => EditorPrefs.SetInt(EditorPrefsPrefix + "restart-editor-after-uploads", value);
         }
 

--- a/Editor/Preferences.cs
+++ b/Editor/Preferences.cs
@@ -49,5 +49,23 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
             get => EditorPrefs.GetBool(EditorPrefsPrefix + "continue-upload-on-error", true);
             set => EditorPrefs.SetBool(EditorPrefsPrefix + "continue-upload-on-error", value);
         }
+
+        public static bool IsRestartEditorAfterUploadsEnabled
+        {
+            get => EditorPrefs.GetBool(EditorPrefsPrefix + "enable-restart-editor-after-uploads", false);
+            set => EditorPrefs.SetBool(EditorPrefsPrefix + "enable-restart-editor-after-uploads", value);
+        }
+
+        public static int RestartEditorAfterUploads
+        {
+            get => EditorPrefs.GetInt(EditorPrefsPrefix + "restart-editor-after-uploads", 0);
+            set => EditorPrefs.SetInt(EditorPrefsPrefix + "restart-editor-after-uploads", value);
+        }
+
+        public static bool RestartBeforeFirstUpload
+        {
+            get => EditorPrefs.GetBool(EditorPrefsPrefix + "restart-before-first-upload", false);
+            set => EditorPrefs.SetBool(EditorPrefsPrefix + "restart-before-first-upload", value);
+        }
     }
 }

--- a/Editor/UploaderProgressAsset.cs
+++ b/Editor/UploaderProgressAsset.cs
@@ -49,6 +49,19 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
         /// </summary>
         public bool continueUploadOnError;
 
+        /// <summary>
+        /// Whether to restart the editor before starting the first upload.
+        /// </summary>
+        public bool restartBeforeFirstUpload;
+        /// <summary>
+        /// Whether to restart the editor during the upload process.
+        /// </summary>
+        public bool restartDuringUpload;
+        /// <summary>
+        /// How many uploads have to be done before restarting the editor. Must be at least 1.
+        /// </summary>
+        public int restartAfterUploads;
+
         // Mutable fields that describe the current progress of the upload
         /// <summary>
         /// The index of the current upload is in progress.
@@ -71,6 +84,10 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
         /// The list of errors that occurred during the upload.
         /// </summary>
         public List<UploadErrorInfo> uploadErrors = new();
+        /// <summary>
+        /// Whether the editor is currently restarting.
+        /// </summary>
+        public bool isRestartingEditor = false;
 
         private bool isDeleting = false;
         private static bool isReloading = false;

--- a/Editor/Utils.cs
+++ b/Editor/Utils.cs
@@ -84,7 +84,21 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
 
         public static void RestartEditor()
         {
-            EditorApplication.OpenProject(Environment.CurrentDirectory);
+            var args = Environment.GetCommandLineArgs().ToList();
+            var projectPathArgIndex = args.IndexOf("-projectPath");
+            if (projectPathArgIndex != -1)
+            {
+                if (projectPathArgIndex + 1 > args.Count)
+                {
+                    args.RemoveRange(projectPathArgIndex, 2);
+                }
+                else
+                {
+                    args.RemoveAt(projectPathArgIndex);
+                }
+            }
+
+            EditorApplication.OpenProject(Environment.CurrentDirectory, args.ToArray());
         }
     }
 

--- a/Editor/Utils.cs
+++ b/Editor/Utils.cs
@@ -81,6 +81,11 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
                 }
             }
         }
+
+        public static void RestartEditor()
+        {
+            EditorApplication.OpenProject(Environment.CurrentDirectory);
+        }
     }
 
     class PreventEnteringPlayModeScope : IDisposable


### PR DESCRIPTION
> [!IMPORTANT]
> This is copy of #144 , former pull request was accidently closed due to branch settings modify on my fork.

- **Please notice that this pull request was only tested on Windows.**
- **All auto restart features are disabled by default**
- User need to ensure that the editor window is **foreground and focus at least once after the editor restart** due to how `EditorApplication.delayCall` behaviour.

## This pull request add 2 features to CAU

- Restart editor before first upload.
- Restart editor after `x` avatars uploaded.

## To prevent asking user prompt after editor restart

- new field `isRestartingEditor` was added to `UploaderProgressAsset.cs`
- `UploadOrchestrator.ResumeUpload()` will check this flag to decied should we asking for user prompt or just continue.

## But why require user interaction after restart?

- `EditorApplication.delayCall` only called when Unity Window are foreground and focused.
- Unity won't respond to messages like `WM_ACTIVATE`, `WM_ACTVATEAPP`, `WM_SETFOCUS`. (at least `delayCall` won't be call)
- Win32 API like `SetForegroundWindow()` `SwitchToThisWindow()` `BringWindowToTop()` `ShowWindow()` has it's own limitation (e.g [Foreground activation permission is like love: You can’t steal it, it has to be given to you](https://devblogs.microsoft.com/oldnewthing/20090220-00/?p=19083)) and will disturb user.

Actually, Multi-Platform Build & Publish will suffer from same issues. Since `ResumeUpload()` and almost whole VRChat toolchain rely on `EditorApplication.delayCall`.

Merge this pull request will close #140 
It's also a workaround of #117 

<img width="699" height="946" alt="image" src="https://github.com/user-attachments/assets/23acc7b4-2d6b-464a-8324-8ec57e40b78b" />
