### PR TITLE
feat: pause upload and psuse on error

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog].
 ### Added
 
 - Handle `ApiErrorException` and provide details about request and api error during upload. [`#150`](https://github.com/anatawa12/ContinuousAvatarUploader/pull/150)
+- Allow user pause upload after current avatar uploaded. [`#156`](https://github.com/anatawa12/ContinuousAvatarUploader/pull/158)
+  - Or, automatically pause upload when any error occurred during build or upload.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog].
 ### Added
 
 - Handle `ApiErrorException` and provide details about request and api error during upload. [`#150`](https://github.com/anatawa12/ContinuousAvatarUploader/pull/150)
+- Allow user pause upload after current avatar uploaded. [`#156`](https://github.com/anatawa12/ContinuousAvatarUploader/pull/158)
+  - Or, automatically pause upload when any error occurred during build or upload.
 
 ### Changed
 

--- a/Editor/ContinuousAvatarUploader.cs
+++ b/Editor/ContinuousAvatarUploader.cs
@@ -142,9 +142,31 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
                 {
                     EditorGUILayout.ObjectField("Uploading", _currentUploadingAvatar, typeof(AvatarUploadSetting), true);
                 }
+                else if (UploadOrchestrator.IsPauseRequested())
+                {
+                    if (!UploadOrchestrator.IsPauseDueToError())
+                    {
+                        GUILayout.Label("Upload Paused");
+                    }
+                    else
+                    {
+                        GUILayout.Label("Upload Paused due to error. Please check the error and choose to resume or abort upload.");
+                    }
+                }
                 else
                 {
                     GUILayout.Label("Sleeping a little");
+                }
+
+                if (!UploadOrchestrator.IsPauseRequested())
+                {
+                    if (GUILayout.Button("PAUSE UPLOAD AFTER CURRENT UPLOAD"))
+                        UploadOrchestrator.RequestPauseUpload();
+                }
+                else
+                {
+                    if (GUILayout.Button("RESUME PAUSED UPLOAD"))
+                        UploadOrchestrator.ResumePausedUpload();
                 }
 
                 if (GUILayout.Button("ABORT UPLOAD"))
@@ -172,6 +194,10 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
                 new GUIContent("Continue upload other avatars on build or upload error",
                     "If this is enabled, CAU will continue uploading other avatars even if some avatar build or upload (if reach retry count limit) fails."),
                 Preferences.ContinueUploadOnError);
+            Preferences.PauseUploadOnError = EditorGUILayout.ToggleLeft(
+                new GUIContent("Pause upload on build or upload error",
+                    "If this is enabled, CAU will pause uploading when some avatar build or upload (if reach retry count limit) fails, and you can choose to resume or abort upload after checking the error."),
+                Preferences.PauseUploadOnError);
             Preferences.RetryCount = EditorGUILayout.IntField(
                 new GUIContent("Retry Count", "The number of retries to attempt for each upload. Zero means no retries, so only one attempt will be made."),
                 Preferences.RetryCount);
@@ -412,6 +438,7 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
             progress.rollbackPlatform = Preferences.RollbackBuildPlatform;
             progress.retryCount = Preferences.RetryCount;
             progress.continueUploadOnError = Preferences.ContinueUploadOnError;
+            progress.pauseUploadOnError = Preferences.PauseUploadOnError;
             UploadOrchestrator.StartUpload(progress);
         }
 

--- a/Editor/Preferences.cs
+++ b/Editor/Preferences.cs
@@ -49,5 +49,11 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
             get => EditorPrefs.GetBool(EditorPrefsPrefix + "continue-upload-on-error", true);
             set => EditorPrefs.SetBool(EditorPrefsPrefix + "continue-upload-on-error", value);
         }
+
+        public static bool PauseUploadOnError
+        {
+            get => EditorPrefs.GetBool(EditorPrefsPrefix + "pause-upload-on-error", false);
+            set => EditorPrefs.SetBool(EditorPrefsPrefix + "pause-upload-on-error", value);
+        }
     }
 }

--- a/Editor/UploadOrchestrator.cs
+++ b/Editor/UploadOrchestrator.cs
@@ -29,6 +29,8 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
 
         static UploadOrchestrator() => EditorApplication.delayCall += ResumeUpload;
 
+        private static bool _isPauseDueToError;
+        [CanBeNull] private static TaskCompletionSource<object> _uploadPauseTcs; 
         private static CancellationTokenSource _cancellationTokenSource = new();
         private static CancellationToken CancellationToken => _cancellationTokenSource.Token;
 
@@ -93,6 +95,8 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
 
             Log($"Starting upload with {asset.uploadSettings.Length} Avatars");
             _cancellationTokenSource = new CancellationTokenSource();
+            _uploadPauseTcs = null;
+            _isPauseDueToError = false;
 
             // Select the first platform to upload to.
             var currentPlatform = Uploader.GetCurrentTargetPlatform();
@@ -140,7 +144,25 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
             }
         }
 
-        public static void CancelUpload() => _cancellationTokenSource.Cancel();
+        public static void CancelUpload()
+        {
+            _cancellationTokenSource.Cancel();
+            _uploadPauseTcs?.SetResult(null);
+        }
+
+        public static void RequestPauseUpload(bool dueToError = false) {
+            _isPauseDueToError = dueToError;
+            _uploadPauseTcs = new TaskCompletionSource<object>();
+        }
+
+        public static void ResumePausedUpload()
+        {
+            _uploadPauseTcs?.TrySetResult(null);
+            _isPauseDueToError = false;
+        }
+
+        public static bool IsPauseRequested() => _uploadPauseTcs != null && !_uploadPauseTcs.Task.IsCompleted;
+        public static bool IsPauseDueToError() => _isPauseDueToError;
 
         private static bool _uploadInProgress = false;
 
@@ -175,6 +197,7 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
 
                 // sleep for a while to avoid overwhelming the server
                 await Task.Delay(asset.sleepMilliseconds);
+                if (_uploadPauseTcs != null) await _uploadPauseTcs.Task;
 
                 var currentPlatform = Uploader.GetCurrentTargetPlatform();
                 if (currentPlatform != asset.uploadingTargetPlatform)
@@ -269,6 +292,12 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
                     asset.Save();
                     WithTryCatch(() => OnUploadSingleAvatarFailed?.Invoke(asset, avatarToUpload, new List<Exception> { exception }));
 
+                    if (asset.pauseUploadOnError)
+                    {
+                        Log("Pause upload on error is enabled, so we are pausing the upload due to the error.");
+                        RequestPauseUpload(true);
+                    }
+
                     if (!asset.continueUploadOnError)
                     {
                         Log("Continue upload other avatars on error is disabled, so we are finishing the upload due to the error.");
@@ -304,6 +333,7 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
                 _uploadInProgress = false;
             }
 
+            if (_uploadPauseTcs != null) await _uploadPauseTcs.Task;
             // Continue uploading the next avatar.
             await UploadNextAvatar(asset);
         }

--- a/Editor/UploaderProgressAsset.cs
+++ b/Editor/UploaderProgressAsset.cs
@@ -49,6 +49,11 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
         /// </summary>
         public bool continueUploadOnError;
 
+        /// <summary>
+        /// Whether to pause the upload process when a build or upload error occurs.
+        /// </summary>
+        public bool pauseUploadOnError;
+
         // Mutable fields that describe the current progress of the upload
         /// <summary>
         /// The index of the current upload is in progress.


### PR DESCRIPTION
## Description

This pull request add 2 features to CAU:

- Allow user pause upload after current avatar uploaded.
- Options to pause upload when (build or upload) error occurred.

It will be useful when user's internet connection broken during upload, or user just want to pause upload for whatever reason.

By the way, it has been 5 months since last CAU release (include pre-release)..... It will be better to make a pre-release.

## UI Preview

**Settings**

<img width="881" height="588" alt="image" src="https://github.com/user-attachments/assets/0ce0dd7e-baf2-4f5e-9b99-c66dc977a899" />

<details><summary>Uploading</summary>
<img width="858" height="777" alt="image" src="https://github.com/user-attachments/assets/1dcfebe6-f529-4d97-8552-08348cc3b8c4" />
</details> 

<details><summary>Pause by user</summary>
<img width="858" height="805" alt="image" src="https://github.com/user-attachments/assets/766defb3-60c7-49fd-b8bc-113e5c296d2d" />
</details> 

<details><summary>Pause due to error</summary>
<img width="858" height="1039" alt="image" src="https://github.com/user-attachments/assets/d4c86cf5-4087-4e8c-948c-a16d9737a825" />
</details> 

Merged this pull request will close #156 