### PR TITLE
fix: abort upload won't abort sleep between upload

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 
+- Abort upload won't abort sleep between upload. [`#159`](https://github.com/anatawa12/ContinuousAvatarUploader/pull/159)
+
 ### Security
 
 ## [0.3.12] - 2025-12-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 
+- Abort upload won't abort sleep between upload. [`#159`](https://github.com/anatawa12/ContinuousAvatarUploader/pull/159)
+
 ### Security
 
 ## [0.3.12] - 2025-12-20

--- a/Editor/UploadOrchestrator.cs
+++ b/Editor/UploadOrchestrator.cs
@@ -173,8 +173,17 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
                     if (!TrySelectNextPlatform(asset)) return;
                 }
 
-                // sleep for a while to avoid overwhelming the server
-                await Task.Delay(asset.sleepMilliseconds);
+                try
+                {
+                    // sleep for a while to avoid overwhelming the server
+                    await Task.Delay(asset.sleepMilliseconds, CancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    Log("Upload cancelled by user. so we are finishing the upload.");
+                    FinishUpload(asset, true);
+                    return;
+                }
 
                 var currentPlatform = Uploader.GetCurrentTargetPlatform();
                 if (currentPlatform != asset.uploadingTargetPlatform)


### PR DESCRIPTION
Currently when click ABORT UPLOAD in CAU, user still need to wait for sleep completed before actual abort.

This pull request pass `CancellationToken` to `Task.Delay` in order to abort sleep between upload when aborting upload.