### PR TITLE
fix: restore VRCFury PC-to-Android sync when uploading via CAU

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -22,7 +22,6 @@ The format is based on [Keep a Changelog].
 ### Fixed
 
 - VRCFury PC→Android parameter sync when uploading via CAU: set `VRC_SdkBuilder.ActiveBuildType` and invoke `OnSdkUpload*` callbacks. [`#145`](https://github.com/anatawa12/ContinuousAvatarUploader/issues/145)
-  - Calling `OnSdkUpload*` is not a permanent change; we may remove it when the build algorithm changes.
 
 ### Security
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 
+- VRCFury PC→Android parameter sync when uploading via CAU: set `VRC_SdkBuilder.ActiveBuildType` and invoke `OnSdkUpload*` callbacks. [`#145`](https://github.com/anatawa12/ContinuousAvatarUploader/issues/145)
+  - Calling `OnSdkUpload*` is not a permanent change; we may remove it when the build algorithm changes.
+
 ### Security
 
 ## [0.3.12] - 2025-12-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ The format is based on [Keep a Changelog].
 ### Fixed
 
 - VRCFury PC→Android parameter sync when uploading via CAU: set `VRC_SdkBuilder.ActiveBuildType` and invoke `OnSdkUpload*` callbacks. [`#145`](https://github.com/anatawa12/ContinuousAvatarUploader/issues/145)
-  - Calling `OnSdkUpload*` is not a permanent change; we may remove it when the build algorithm changes.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 
+- VRCFury PC→Android parameter sync when uploading via CAU: set `VRC_SdkBuilder.ActiveBuildType` and invoke `OnSdkUpload*` callbacks. [`#145`](https://github.com/anatawa12/ContinuousAvatarUploader/issues/145)
+  - Calling `OnSdkUpload*` is not a permanent change; we may remove it when the build algorithm changes.
+
 ### Security
 
 ## [0.3.12] - 2025-12-20

--- a/Editor/Uploader.cs
+++ b/Editor/Uploader.cs
@@ -334,84 +334,117 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
                 controlPanel.CheckedForIssues = true;
             }
 
-            // build avatar main process
-            string bundlePath;
-            using (new SetBlueprintIdEveryFrame(pipelineManager, pipelineManager.blueprintId))
+            // VRCFury and other tools check ActiveBuildType to distinguish publish uploads from test builds.
+            // The SDK Control Panel sets this before BuildAndUpload, but builder.Build() alone does not.
+            // See https://github.com/anatawa12/ContinuousAvatarUploader/issues/145
+#if CAU_VRCSDK_BASE_3_7_5
+            VRC_SdkBuilder.ActiveBuildType = VRC_SdkBuilder.BuildType.Publish;
+#endif
+            try
             {
-                await AddCopyrightAgreement(pipelineManager.blueprintId);
-                bundlePath = await builder.Build(avatarDescriptor.gameObject);
-
-                ValidateBuiltBundleSize(bundlePath);
-            }
-
-            // get uploaded avatar info
-            vrcAvatar = await VRCApi.GetAvatar(pipelineManager.blueprintId, forceRefresh: true,
-                cancellationToken: cancellationToken);
-
-            vrcAvatar = await UpdateAvatarFallbackTagIfNeeded(pipelineManager, vrcAvatar, cancellationToken: cancellationToken);
-
-            // VRCSDK uses CreateNewAvatar to create new avatar, and UpdateAvatarImage/Bundle to update existing avatar.
-            // However, UpdateAvatarImage/Bundle also works for new avatar so we use them always.
-            // This is simpler and has finer progress reporting.
-
-            if (picturePath != null)
-            {
-                await UploadWithRetry(async () =>
+                // build avatar main process
+                string bundlePath;
+                using (new SetBlueprintIdEveryFrame(pipelineManager, pipelineManager.blueprintId))
                 {
-                    vrcAvatar = await VRCApi.UpdateAvatarImage(vrcAvatar.ID, vrcAvatar, picturePath,
-                        cancellationToken: cancellationToken);
-                });
-            }
+                    await AddCopyrightAgreement(pipelineManager.blueprintId);
+                    bundlePath = await builder.Build(avatarDescriptor.gameObject);
 
-            await UploadWithRetry(async () =>
-            {
-                vrcAvatar = await VRCApi.UpdateAvatarBundle(vrcAvatar.ID, vrcAvatar, bundlePath,
+                    ValidateBuiltBundleSize(bundlePath);
+                }
+
+                // get uploaded avatar info
+                vrcAvatar = await VRCApi.GetAvatar(pipelineManager.blueprintId, forceRefresh: true,
                     cancellationToken: cancellationToken);
-            });
 
-            async Task UploadWithRetry(Func<Task> uploadAction)
-            {
-                var remainingRetries = uploadRetryCount;
-                for (;;)
+                vrcAvatar = await UpdateAvatarFallbackTagIfNeeded(pipelineManager, vrcAvatar, cancellationToken: cancellationToken);
+
+                // VRCSDK uses CreateNewAvatar to create new avatar, and UpdateAvatarImage/Bundle to update existing avatar.
+                // However, UpdateAvatarImage/Bundle also works for new avatar so we use them always.
+                // This is simpler and has finer progress reporting.
+
+                // Invoke OnSdkUpload* events for VRCFury compatibility (DesktopSyncData persistence).
+                // BuildAndUpload invokes these; Build + VRCApi.UpdateAvatar* does not.
+                InvokeSdkEvent(builder, "OnSdkUploadStart", EventArgs.Empty);
+
+                try
                 {
-                    try
+                    if (picturePath != null)
                     {
-                        await uploadAction();
-                        return;
-                    }
-                    catch (UploadException e)
-                    {
-                        if (e.Message == "This file was already uploaded")
+                        await UploadWithRetry(async () =>
                         {
-                            Debug.Log("Uploading skipped: already uploaded");
+                            vrcAvatar = await VRCApi.UpdateAvatarImage(vrcAvatar.ID, vrcAvatar, picturePath,
+                                cancellationToken: cancellationToken);
+                        });
+                    }
+
+                    await UploadWithRetry(async () =>
+                    {
+                        vrcAvatar = await VRCApi.UpdateAvatarBundle(vrcAvatar.ID, vrcAvatar, bundlePath,
+                            cancellationToken: cancellationToken);
+                    });
+
+                    InvokeSdkEvent(builder, "OnSdkUploadSuccess", pipelineManager.blueprintId);
+                }
+                catch (Exception ex)
+                {
+                    InvokeSdkEvent(builder, "OnSdkUploadError", ex.Message);
+                    throw;
+                }
+                finally
+                {
+                    InvokeSdkEvent(builder, "OnSdkUploadFinish", "Avatar upload finished");
+                }
+
+                async Task UploadWithRetry(Func<Task> uploadAction)
+                {
+                    var remainingRetries = uploadRetryCount;
+                    for (;;)
+                    {
+                        try
+                        {
+                            await uploadAction();
+                            return;
                         }
+                        catch (UploadException e)
+                        {
+                            if (e.Message == "This file was already uploaded")
+                            {
+                                Debug.Log("Uploading skipped: already uploaded");
+                            }
 
-                        if (remainingRetries == 0) throw;
-                        remainingRetries--;
+                            if (remainingRetries == 0) throw;
+                            remainingRetries--;
 
-                        var currentTry = uploadRetryCount - remainingRetries;
-                        Debug.LogWarning(
-                            $"Uploading failed with exception, retrying... ({currentTry}/{uploadRetryCount}): {e}");
+                            var currentTry = uploadRetryCount - remainingRetries;
+                            Debug.LogWarning(
+                                $"Uploading failed with exception, retrying... ({currentTry}/{uploadRetryCount}): {e}");
+                        }
+                    }
+                }
+
+                // update description
+                // This process may also not required with 
+                // https://feedback.vrchat.com/open-beta/p/beta-sdk-330-beta1-lack-of-ability-to-update-description-from-code
+                if (platformInfo.versioningEnabled)
+                {
+                    long versionName;
+                    (vrcAvatar.Description, versionName) =
+                        UpdateVersionName(vrcAvatar.Description, platformInfo.versionNamePrefix);
+
+                    await VRCApi.UpdateAvatarInfo(vrcAvatar.ID, vrcAvatar, cancellationToken: cancellationToken);
+
+                    if (platformInfo.gitEnabled)
+                    {
+                        var tagName = platformInfo.tagPrefix + versionName + platformInfo.tagSuffix;
+                        AddGitTag(tagName, avatarDescriptor.name);
                     }
                 }
             }
-
-            // update description
-            // This process may also not required with 
-            // https://feedback.vrchat.com/open-beta/p/beta-sdk-330-beta1-lack-of-ability-to-update-description-from-code
-            if (platformInfo.versioningEnabled)
+            finally
             {
-                long versionName;
-                (vrcAvatar.Description, versionName) =
-                    UpdateVersionName(vrcAvatar.Description, platformInfo.versionNamePrefix);
-
-                await VRCApi.UpdateAvatarInfo(vrcAvatar.ID, vrcAvatar, cancellationToken: cancellationToken);
-
-                if (platformInfo.gitEnabled)
-                {
-                    var tagName = platformInfo.tagPrefix + versionName + platformInfo.tagSuffix;
-                    AddGitTag(tagName, avatarDescriptor.name);
-                }
+#if CAU_VRCSDK_BASE_3_7_5
+                VRC_SdkBuilder.ActiveBuildType = VRC_SdkBuilder.BuildType.None;
+#endif
             }
         }
 
@@ -803,6 +836,61 @@ namespace Anatawa12.ContinuousAvatarUploader.Editor
             }
 
             return vrcAvatar;
+        }
+
+        /// <summary>
+        /// Invokes SDK event handlers via reflection for VRCFury compatibility.
+        /// Events are on IVRCSdkBuilderApi and implemented as private fields in the implementor class
+        /// (possibly on a base type), so we walk the type hierarchy.
+        /// Each subscriber is invoked individually so one failing handler does not skip others.
+        /// Exceptions from events and reflection errors are caught and logged but do not suspend upload.
+        ///
+        /// See <see href="https://github.com/anatawa12/ContinuousAvatarUploader/issues/145">#145</see>.
+        /// </summary>
+        private static void InvokeSdkEvent(IVRCSdkAvatarBuilderApi builder, string eventName, object eventArgs)
+        {
+            try
+            {
+                FieldInfo eventField = null;
+                for (var type = builder.GetType(); type != null; type = type.BaseType)
+                {
+                    eventField = type.GetField(eventName,
+                        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly);
+                    if (eventField != null) break;
+                }
+
+                if (eventField == null)
+                {
+                    // Expected when SDK version lacks these events or the concrete builder differs.
+                    return;
+                }
+
+                var eventDelegate = eventField.GetValue(builder) as Delegate;
+                if (eventDelegate == null)
+                {
+                    // No subscribers
+                    return;
+                }
+
+                foreach (var handler in eventDelegate.GetInvocationList())
+                {
+                    try
+                    {
+                        handler.DynamicInvoke(builder, eventArgs);
+                    }
+                    catch (Exception handlerEx)
+                    {
+                        Debug.LogWarning(
+                            $"[CAU] Exception in SDK event '{eventName}' handler ({handler.Method.DeclaringType?.FullName}.{handler.Method.Name}): {handlerEx.Message}");
+                        Debug.LogException(handlerEx);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[CAU] Exception while invoking SDK event '{eventName}': {ex.Message}");
+                Debug.LogException(ex);
+            }
         }
 
         /// <summary>

--- a/Editor/com.anatawa12.continuous-avatar-uploader.editor.asmdef
+++ b/Editor/com.anatawa12.continuous-avatar-uploader.editor.asmdef
@@ -29,6 +29,11 @@
         },
         {
             "name": "com.vrchat.base",
+            "expression": "3.7.5",
+            "define": "CAU_VRCSDK_BASE_3_7_5"
+        },
+        {
+            "name": "com.vrchat.base",
             "expression": "3.8.0",
             "define": "CAU_VRCSDK_BASE_3_8_0"
         },


### PR DESCRIPTION
## Summary
- Fixes #145
- Set `VRC_SdkBuilder.ActiveBuildType = Publish` during build/upload so VRCFury treats CAU uploads as real publishes (enables DesktopSyncData registration).
- Invoke `OnSdkUpload*` SDK events via reflection (same idea as #147), with base-type field lookup and per-handler exception isolation.

## 動作確認 / Verification
- 私の環境で動作確認を取りました（CAU 経由の PC→Android 連続アップロードで、VRCFury の同期データが期待どおり保存・利用されることを確認）。
- Verified in my environment: PC→Android consecutive upload via CAU works, and VRCFury sync data is persisted/used as expected.

## Notes
- PR #147 alone was not enough because VRCFury skips saving DesktopSyncData when `ActiveBuildType` is `None`.
- `#147` だけでは不十分で、`ActiveBuildType` が `None` のままだと VRCFury 側が DesktopSyncData の保存をスキップします。

## Test plan
- [x] Upload PC then Android via CAU with VRCFury-enabled avatar
- [x] Confirm `%LOCALAPPDATA%\VRCFury\DesktopSyncData\{blueprintId}.json` is created after PC upload
- [x] Confirm Android build no longer shows the incompatible/missing desktop upload warning